### PR TITLE
fix/update_docu_and_crate_names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ matrix:
   include:
     - name: "01_BLINKLED Aarch32"
       install:
-        - sudo apt-get install gcc-arm-linux-gnueabihf
+        - sudo apt-get install gcc-arm-none-eabi
         - cargo install cargo-xbuild
         - cargo install cargo-binutils
-        - rustup target add armv7-unknown-linux-gnueabihf
+        - rustup target add armv7a-none-eabi
         - rustup component add rust-src
         - rustup component add llvm-tools-preview        
         - cd ./01_BLINKLED
@@ -27,10 +27,10 @@ matrix:
 
     - name: "01_BLINKLED Aarch64"
       install:
-        - sudo apt-get install gcc-aarch64-linux-gnu
+        - sudo apt-get install gcc-aarch64-none-elf
         - cargo install cargo-xbuild
         - cargo install cargo-binutils
-        - rustup target add aarch64-unknown-linux-gnu
+        - rustup target add aarch64-unknown-none
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         - cd ./01_BLINKLED

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,17 @@ rust:
 matrix:
   fast_finish: false
   include:
-#    - name: "01_BLINKLED Aarch32"
-#      install:
-#        - sudo apt-get install gcc-arm-none-eabi
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add armv7a-none-eabi
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview        
-#        - cd ./01_BLINKLED
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 32 travis
+    - name: "01_BLINKLED Aarch32"
+      install:
+        - sudo apt-get install gcc-arm-none-eabi
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add armv7a-none-eabi
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview        
+        - cd ./01_BLINKLED
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 32 travis
 
     - name: "01_BLINKLED Aarch64"
       install:
@@ -37,74 +37,74 @@ matrix:
         - sudo chmod ugo+x ./build.sh
       script: ./build.sh 64 travis
 
-#    - name: "02_CONSOLE Aarch32"
-#      install:
-#        - sudo apt-get install gcc-arm-none-eabi
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add armv7a-none-eabi
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview
-#        - cd ./02_CONSOLE
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 32 travis
-#
-#    - name: "02_CONSOLE Aarch64"
-#      install:
-#        - sudo apt-get install gcc-aarch64-linux-gnu
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add aarch64-unknown-linux-gnu
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview
-#        - cd ./02_CONSOLE
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 64 travis
-#
-#    - name: "03_INTERRUPT Aarch32"
-#      install:
-#        - sudo apt-get install gcc-arm-none-eabi
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add armv7a-none-eabi
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview
-#        - cd ./03_INTERRUPT
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 32 travis
-#
-#    - name: "03_INTERRUPT Aarch64"
-#      install:
-#        - sudo apt-get install gcc-aarch64-linux-gnu
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add aarch64-unknown-linux-gnu
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview
-#        - cd ./03_INTERRUPT
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 64 travis
-#
-#    - name: "04_I2C Aarch32"
-#      install:
-#        - sudo apt-get install gcc-arm-none-eabi
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add armv7a-none-eabi
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview
-#        - cd ./04_I2C
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 32 travis
-#
-#    - name: "04_I2C Aarch64"
-#      install:
-#        - sudo apt-get install gcc-aarch64-linux-gnu
-#        - cargo install cargo-xbuild
-#        - cargo install cargo-binutils
-#        - rustup target add aarch64-unknown-linux-gnu
-#        - rustup component add rust-src
-#        - rustup component add llvm-tools-preview
-#        - cd ./04_I2C
-#        - sudo chmod ugo+x ./build.sh
-#      script: ./build.sh 64 travis
+    - name: "02_CONSOLE Aarch32"
+      install:
+        - sudo apt-get install gcc-arm-none-eabi
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add armv7a-none-eabi
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview
+        - cd ./02_CONSOLE
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 32 travis
+
+    - name: "02_CONSOLE Aarch64"
+      install:
+        - sudo apt-get install gcc-aarch64-linux-gnu
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add aarch64-unknown-linux-gnu
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview
+        - cd ./02_CONSOLE
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 64 travis
+
+    - name: "03_INTERRUPT Aarch32"
+      install:
+        - sudo apt-get install gcc-arm-none-eabi
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add armv7a-none-eabi
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview
+        - cd ./03_INTERRUPT
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 32 travis
+
+    - name: "03_INTERRUPT Aarch64"
+      install:
+        - sudo apt-get install gcc-aarch64-linux-gnu
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add aarch64-unknown-linux-gnu
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview
+        - cd ./03_INTERRUPT
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 64 travis
+
+    - name: "04_I2C Aarch32"
+      install:
+        - sudo apt-get install gcc-arm-none-eabi
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add armv7a-none-eabi
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview
+        - cd ./04_I2C
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 32 travis
+
+    - name: "04_I2C Aarch64"
+      install:
+        - sudo apt-get install gcc-aarch64-linux-gnu
+        - cargo install cargo-xbuild
+        - cargo install cargo-binutils
+        - rustup target add aarch64-unknown-linux-gnu
+        - rustup component add rust-src
+        - rustup component add llvm-tools-preview
+        - cd ./04_I2C
+        - sudo chmod ugo+x ./build.sh
+      script: ./build.sh 64 travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,21 @@ rust:
 matrix:
   fast_finish: false
   include:
-    - name: "01_BLINKLED Aarch32"
-      install:
-        - sudo apt-get install gcc-arm-none-eabi
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add armv7a-none-eabi
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview        
-        - cd ./01_BLINKLED
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 32 travis
+#    - name: "01_BLINKLED Aarch32"
+#      install:
+#        - sudo apt-get install gcc-arm-none-eabi
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add armv7a-none-eabi
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview        
+#        - cd ./01_BLINKLED
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 32 travis
 
     - name: "01_BLINKLED Aarch64"
       install:
-        - sudo apt-get install gcc-aarch64-none-elf
+        - sudo apt-get install aarch64-none-elf-gcc
         - cargo install cargo-xbuild
         - cargo install cargo-binutils
         - rustup target add aarch64-unknown-none
@@ -37,74 +37,74 @@ matrix:
         - sudo chmod ugo+x ./build.sh
       script: ./build.sh 64 travis
 
-    - name: "02_CONSOLE Aarch32"
-      install:
-        - sudo apt-get install gcc-arm-linux-gnueabihf
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add armv7-unknown-linux-gnueabihf
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview
-        - cd ./02_CONSOLE
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 32 travis
-
-    - name: "02_CONSOLE Aarch64"
-      install:
-        - sudo apt-get install gcc-aarch64-linux-gnu
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add aarch64-unknown-linux-gnu
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview
-        - cd ./02_CONSOLE
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 64 travis
-
-    - name: "03_INTERRUPT Aarch32"
-      install:
-        - sudo apt-get install gcc-arm-linux-gnueabihf
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add armv7-unknown-linux-gnueabihf
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview
-        - cd ./03_INTERRUPT
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 32 travis
-
-    - name: "03_INTERRUPT Aarch64"
-      install:
-        - sudo apt-get install gcc-aarch64-linux-gnu
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add aarch64-unknown-linux-gnu
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview
-        - cd ./03_INTERRUPT
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 64 travis
-
-    - name: "04_I2C Aarch32"
-      install:
-        - sudo apt-get install gcc-arm-linux-gnueabihf
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add armv7-unknown-linux-gnueabihf
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview
-        - cd ./04_I2C
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 32 travis
-
-    - name: "04_I2C Aarch64"
-      install:
-        - sudo apt-get install gcc-aarch64-linux-gnu
-        - cargo install cargo-xbuild
-        - cargo install cargo-binutils
-        - rustup target add aarch64-unknown-linux-gnu
-        - rustup component add rust-src
-        - rustup component add llvm-tools-preview
-        - cd ./04_I2C
-        - sudo chmod ugo+x ./build.sh
-      script: ./build.sh 64 travis
+#    - name: "02_CONSOLE Aarch32"
+#      install:
+#        - sudo apt-get install gcc-arm-none-eabi
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add armv7a-none-eabi
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview
+#        - cd ./02_CONSOLE
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 32 travis
+#
+#    - name: "02_CONSOLE Aarch64"
+#      install:
+#        - sudo apt-get install gcc-aarch64-linux-gnu
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add aarch64-unknown-linux-gnu
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview
+#        - cd ./02_CONSOLE
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 64 travis
+#
+#    - name: "03_INTERRUPT Aarch32"
+#      install:
+#        - sudo apt-get install gcc-arm-none-eabi
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add armv7a-none-eabi
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview
+#        - cd ./03_INTERRUPT
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 32 travis
+#
+#    - name: "03_INTERRUPT Aarch64"
+#      install:
+#        - sudo apt-get install gcc-aarch64-linux-gnu
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add aarch64-unknown-linux-gnu
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview
+#        - cd ./03_INTERRUPT
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 64 travis
+#
+#    - name: "04_I2C Aarch32"
+#      install:
+#        - sudo apt-get install gcc-arm-none-eabi
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add armv7a-none-eabi
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview
+#        - cd ./04_I2C
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 32 travis
+#
+#    - name: "04_I2C Aarch64"
+#      install:
+#        - sudo apt-get install gcc-aarch64-linux-gnu
+#        - cargo install cargo-xbuild
+#        - cargo install cargo-binutils
+#        - rustup target add aarch64-unknown-linux-gnu
+#        - rustup component add rust-src
+#        - rustup component add llvm-tools-preview
+#        - cd ./04_I2C
+#        - sudo chmod ugo+x ./build.sh
+#      script: ./build.sh 64 travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 
     - name: "01_BLINKLED Aarch64"
       install:
-        - sudo apt-get install aarch64-none-elf-gcc
+        - sudo apt-get install gcc-aarch64-linux-gnu
         - cargo install cargo-xbuild
         - cargo install cargo-binutils
         - rustup target add aarch64-unknown-none

--- a/01_BLINKLED/Cargo.toml
+++ b/01_BLINKLED/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "01_blinkled"
+name = "TUT_01_blinkled"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
 version = "0.0.1" # remember to update html_root_url
 description = """
@@ -20,8 +20,7 @@ cc = "1.0"
 
 [dependencies]
 ruspiro-boot = { version = "0.3", features = ["ruspiro_pi3"] }
-ruspiro-allocator = { version = "0.3" }
-ruspiro-gpio = { version = "0.3", features = ["ruspiro_pi3"] }
-ruspiro-timer = { version = "0.3", features = ["ruspiro_pi3"] }
+ruspiro-allocator = { version = "0.4" }
+ruspiro-gpio = { version = "0.4", features = ["ruspiro_pi3"] }
+ruspiro-timer = { version = "0.4", features = ["ruspiro_pi3"] }
 
-[features]

--- a/01_BLINKLED/build.rs
+++ b/01_BLINKLED/build.rs
@@ -3,17 +3,20 @@ use std::{env, fs, path::Path};
 fn main() {
     // copy the linker script from the boot crate to the current directory
     // so it will be invoked by the linker
-    let ld_source = env::var_os("DEP_RUSPIRO_BOOT_LINKERSCRIPT")
-        .expect("error in ruspiro build, `ruspiro-boot` not a dependency?")
-        .to_str()
-        .unwrap()
-        .replace("\\", "/");
-    let src_file = Path::new(&ld_source);
-    let trg_file = format!(
-        "{}/{}",
-        env::current_dir().unwrap().display(),
-        src_file.file_name().unwrap().to_str().unwrap()
-    );
-    println!("Copy linker script from {:?}, to {:?}", src_file, trg_file);
-    fs::copy(src_file, trg_file).unwrap();
+    if let Some(link_script) = env::var_os("DEP_RUSPIRO_BOOT_LINKERSCRIPT") {
+        let ld_source = link_script
+            .to_str()
+            .unwrap()
+            .replace("\\", "/");
+        let src_file = Path::new(&ld_source);
+        let trg_file = format!(
+            "{}/{}",
+            env::current_dir().unwrap().display(),
+            src_file.file_name().unwrap().to_str().unwrap()
+        );
+        println!("Copy linker script from {:?}, to {:?}", src_file, trg_file);
+        fs::copy(src_file, trg_file).unwrap();
+    } else {
+        println!("error in ruspiro build, `ruspiro-boot` not a dependency?");
+    }
 }

--- a/01_BLINKLED/build.sh
+++ b/01_BLINKLED/build.sh
@@ -18,7 +18,7 @@ if [ $1 = "64" ]
             then
                 PREFIX=aarch64-none-elf-
             else
-                PREFIX=aarch64-linux-gnu-
+                PREFIX=aarch64-none-elf- #linux-gnu-
         fi
         CFLAGS="-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
@@ -32,7 +32,7 @@ elif [ $1 = "32" ]
             then
                 PREFIX=arm-none-eabi-
             else
-                PREFIX=arm-linux-gnueabihf-
+                PREFIX=arm-none-eabi- #linux-gnueabihf-
         fi
         CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"

--- a/01_BLINKLED/build.sh
+++ b/01_BLINKLED/build.sh
@@ -18,7 +18,7 @@ if [ $1 = "64" ]
             then
                 PREFIX=aarch64-none-elf-
             else
-                PREFIX=aarch64-none-elf- #linux-gnu-
+                PREFIX=aarch64-linux-gnu-
         fi
         CFLAGS="-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"

--- a/01_BLINKLED/build.sh
+++ b/01_BLINKLED/build.sh
@@ -16,13 +16,13 @@ if [ $1 = "64" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=aarch64-elf-
+                PREFIX=aarch64-none-elf-
             else
                 PREFIX=aarch64-linux-gnu-
         fi
         CFLAGS="-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0 -C link-arg=-T./link64.ld"
-        TARGET="aarch64-unknown-linux-gnu"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+        TARGET="aarch64-unknown-none"
         KERNEL="kernel8.img"
 elif [ $1 = "32" ]
     then
@@ -30,16 +30,16 @@ elif [ $1 = "32" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=arm-eabi-
+                PREFIX=arm-none-eabi-
             else
                 PREFIX=arm-linux-gnueabihf-
         fi
-        CFLAGS="-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0"
-        TARGET="armv7-unknown-linux-gnueabihf"
+        CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+        TARGET="armv7a-none-eabi"
         KERNEL="kernel7.img"
 else
-    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64" followed by "deploy" if you like to deploy to the device'
+    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64"'
     exit 1
 fi
 
@@ -47,8 +47,9 @@ export CFLAGS="${CFLAGS}"
 export RUSTFLAGS="${RUSTFLAGS}"
 export CC="${PREFIX}gcc"
 export AR="${PREFIX}ar"
-export TARGET="${TARGET}"
-export KERNEL="${KERNEL}"
 
-cargo xbuild --target ${TARGET} --release
-cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+cargo xbuild --target ${TARGET} --release && ${PREFIX}objcopy -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+# cargo objcopy tries to re-build the crates without the propper cross compile target since whatever version
+# so don't use it but rather use the arm toolchain objcopy to achieve the same
+#cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+

--- a/01_BLINKLED/build.sh
+++ b/01_BLINKLED/build.sh
@@ -27,13 +27,8 @@ if [ $1 = "64" ]
 elif [ $1 = "32" ]
     then
         # aarch32
-        # use the right compiler toolchain prefix when building on travis
-        if [ -z "$2" ]
-            then
-                PREFIX=arm-none-eabi-
-            else
-                PREFIX=arm-none-eabi- #linux-gnueabihf-
-        fi
+        # use the right compiler toolchain prefix when building
+        PREFIX=arm-none-eabi-
         CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
         TARGET="armv7a-none-eabi"

--- a/01_BLINKLED/makefile
+++ b/01_BLINKLED/makefile
@@ -1,22 +1,22 @@
 #*********************************************************************************
 # Makefile to build the kernel binary ready to be pushed to the Raspberry Pi
 #*********************************************************************************
-all32: export CFLAGS = -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all32: export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0
-all32: export CC = arm-eabi-gcc.exe
-all32: export AR = arm-eabi-ar.exe
+all32: export CFLAGS = -mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all32: export RUSTFLAGS = -C linker=arm-none-eabi-gcc.exe -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld
+all32: export CC = arm-none-eabi-gcc.exe
+all32: export AR = arm-none-eabi-ar.exe
 all32: kernel7
-	cargo objcopy -- -O binary .\\target\\armv7-unknown-linux-gnueabihf\\release\\kernel .\\target\\kernel7.img
+	arm-none-eabi-objcopy -O binary .\\target\\armv7a-none-eabi\\release\\kernel .\\target\\kernel7.img
 
 kernel7:
-	cargo xbuild --target armv7-unknown-linux-gnueabihf --release --bin kernel --target-dir ./target/
+	cargo xbuild --target armv7a-none-eabi --release --bin kernel --target-dir ./target/
 
 all64: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all64: export RUSTFLAGS = -C linker=aarch64-elf-gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld -C opt-level=3 -C debuginfo=0
-all64: export CC = aarch64-elf-gcc
-all64: export AR = aarch64-elf-ar
+all64: export RUSTFLAGS = -C linker=aarch64-none-elf-gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld
+all64: export CC = aarch64-none-elf-gcc
+all64: export AR = aarch64-none-elf-ar
 all64: kernel8
-	cargo objcopy -- -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
+	aarch64-none-elf-objcopy -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
 
 kernel8:
 	cargo xbuild --target aarch64-unknown-linux-gnu --release --bin kernel --target-dir ./target/

--- a/01_BLINKLED/src/kernel.rs
+++ b/01_BLINKLED/src/kernel.rs
@@ -1,4 +1,4 @@
-/*********************************************************************************************************************** 
+/***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
  * 
  * Author: André Borrmann
@@ -10,12 +10,12 @@
 //! # Hello World
 //! 
 //! This is the initial RusPiRo tutorial. It's the bare metal version of a "Hello World" programm greeting the world
-//! by blinking a LED. It's intention is - while limited in functionality - to verify the tools and programs are properly
-//! installed and configured to build a running bare metal kernel for the Raspberry Pi.
+//! by blinking a LED. It's intention is - while limited in functionality - to verify the tools and programs are 
+//! properly installed and configured to build a running bare metal kernel for the Raspberry Pi.
 //! 
-//! The Raspberry Pi contains 4 cores that will execute independently from each other. So we assigned a dedicated GPIO pin
-//! to each core. If using all 4 cores is not required adjust the `ruspiro-boot`dependency to
-//! activiate the `singlecore`feature like so:
+//! The Raspberry Pi contains 4 cores that will execute independently from each other. So we assigned a dedicated GPIO 
+//! pin to each core. If using all 4 cores is not required adjust the `ruspiro-boot` dependency to
+//! activiate the `singlecore` feature like so:
 //! ```toml
 //! [dependencies]
 //! ruspiro-boot = { version = "0.3", features = ["ruspiro_pi3", "singlecore"] }

--- a/01_BLINKLED/src/kernel.rs
+++ b/01_BLINKLED/src/kernel.rs
@@ -47,10 +47,10 @@ run_with!(running);
 fn running(core: u32) -> ! {
     // based on the core provided use a different GPIO pin to blink a different LED
     let pin = match core {
-        0 => GPIO.take_for(|gpio| gpio.get_pin(17)).unwrap().to_output(),
-        1 => GPIO.take_for(|gpio| gpio.get_pin(18)).unwrap().to_output(),
-        2 => GPIO.take_for(|gpio| gpio.get_pin(20)).unwrap().to_output(),
-        3 => GPIO.take_for(|gpio| gpio.get_pin(21)).unwrap().to_output(),
+        0 => GPIO.take_for(|gpio| gpio.get_pin(17)).unwrap().into_output(),
+        1 => GPIO.take_for(|gpio| gpio.get_pin(18)).unwrap().into_output(),
+        2 => GPIO.take_for(|gpio| gpio.get_pin(20)).unwrap().into_output(),
+        3 => GPIO.take_for(|gpio| gpio.get_pin(21)).unwrap().into_output(),
         _ => unreachable!()
     };
 
@@ -58,8 +58,8 @@ fn running(core: u32) -> ! {
     // blinking the LED
     loop {
         pin.high();
-        timer::sleep(10000 + 10000*core as u64);
+        timer::sleep(timer::Useconds(10000 + 10000*core as u64));
         pin.low();
-        timer::sleep(15000 + 5000*core as u64);
+        timer::sleep(timer::Useconds(15000 + 5000*core as u64));
     } // never return here...
 }

--- a/02_CONSOLE/Cargo.toml
+++ b/02_CONSOLE/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "02_console"
+name = "TUT_02_console"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
 version = "0.0.1" # remember to update html_root_url
 description = """
@@ -20,6 +20,6 @@ cc = "1.0"
 
 [dependencies]
 ruspiro-boot = { version = "0.3", features = ["ruspiro_pi3"] }
-ruspiro-allocator = "0.3"
+ruspiro-allocator = "0.4"
 
 [features]

--- a/02_CONSOLE/build.sh
+++ b/02_CONSOLE/build.sh
@@ -27,13 +27,8 @@ if [ $1 = "64" ]
 elif [ $1 = "32" ]
     then
         # aarch32
-        # use the right compiler toolchain prefix when building on travis
-        if [ -z "$2" ]
-            then
-                PREFIX=arm-none-eabi-
-            else
-                PREFIX=arm-linux-gnueabihf-
-        fi
+        # use the right compiler toolchain prefix when building
+        PREFIX=arm-none-eabi-
         CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
         TARGET="armv7a-none-eabi"

--- a/02_CONSOLE/build.sh
+++ b/02_CONSOLE/build.sh
@@ -16,13 +16,13 @@ if [ $1 = "64" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=aarch64-elf-
+                PREFIX=aarch64-none-elf-
             else
                 PREFIX=aarch64-linux-gnu-
         fi
         CFLAGS="-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0 -C link-arg=-T./link64.ld"
-        TARGET="aarch64-unknown-linux-gnu"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+        TARGET="aarch64-unknown-none"
         KERNEL="kernel8.img"
 elif [ $1 = "32" ]
     then
@@ -30,16 +30,16 @@ elif [ $1 = "32" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=arm-eabi-
+                PREFIX=arm-none-eabi-
             else
                 PREFIX=arm-linux-gnueabihf-
         fi
-        CFLAGS="-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0"
-        TARGET="armv7-unknown-linux-gnueabihf"
+        CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+        TARGET="armv7a-none-eabi"
         KERNEL="kernel7.img"
 else
-    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64" followed by "deploy" if you like to deploy to the device'
+    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64"'
     exit 1
 fi
 
@@ -47,8 +47,9 @@ export CFLAGS="${CFLAGS}"
 export RUSTFLAGS="${RUSTFLAGS}"
 export CC="${PREFIX}gcc"
 export AR="${PREFIX}ar"
-export TARGET="${TARGET}"
-export KERNEL="${KERNEL}"
 
-cargo xbuild --target ${TARGET} --release
-cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+cargo xbuild --target ${TARGET} --release && ${PREFIX}objcopy -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+# cargo objcopy tries to re-build the crates without the propper cross compile target since whatever version
+# so don't use it but rather use the arm toolchain objcopy to achieve the same
+#cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+

--- a/02_CONSOLE/makefile
+++ b/02_CONSOLE/makefile
@@ -1,22 +1,22 @@
 #*********************************************************************************
 # Makefile to build the kernel binary ready to be pushed to the Raspberry Pi
 #*********************************************************************************
-all32: export CFLAGS = -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all32: export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0
-all32: export CC = arm-eabi-gcc.exe
-all32: export AR = arm-eabi-ar.exe
+all32: export CFLAGS = -mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all32: export RUSTFLAGS = -C linker=arm-none-eabi-gcc.exe -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld
+all32: export CC = arm-none-eabi-gcc.exe
+all32: export AR = arm-none-eabi-ar.exe
 all32: kernel7
-	cargo objcopy -- -O binary .\\target\\armv7-unknown-linux-gnueabihf\\release\\kernel .\\target\\kernel7.img
+	arm-none-eabi-objcopy -O binary .\\target\\armv7a-none-eabi\\release\\kernel .\\target\\kernel7.img
 
 kernel7:
-	cargo xbuild --target armv7-unknown-linux-gnueabihf --release --bin kernel --target-dir ./target/
+	cargo xbuild --target armv7a-none-eabi --release --bin kernel --target-dir ./target/
 
 all64: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all64: export RUSTFLAGS = -C linker=aarch64-elf-gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld -C opt-level=3 -C debuginfo=0
-all64: export CC = aarch64-elf-gcc
-all64: export AR = aarch64-elf-ar
+all64: export RUSTFLAGS = -C linker=aarch64-none-elf-gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld
+all64: export CC = aarch64-none-elf-gcc
+all64: export AR = aarch64-none-elf-ar
 all64: kernel8
-	cargo objcopy -- -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
+	aarch64-none-elf-objcopy -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
 
 kernel8:
 	cargo xbuild --target aarch64-unknown-linux-gnu --release --bin kernel --target-dir ./target/

--- a/03_INTERRUPT/Cargo.toml
+++ b/03_INTERRUPT/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "03_interrupt"
+name = "TUT_03_interrupt"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
 version = "0.0.1" # remember to update html_root_url
 description = """
@@ -20,8 +20,8 @@ cc = "1.0"
 
 [dependencies]
 ruspiro-boot = { version = "0.3", features = [ "ruspiro_pi3", "singlecore" ] }
-ruspiro-allocator = "0.3"
+ruspiro-allocator = "0.4"
 ruspiro-interrupt = "0.3"
-ruspiro-register = "0.3"
+ruspiro-register = "0.4"
 
 [features]

--- a/03_INTERRUPT/build.sh
+++ b/03_INTERRUPT/build.sh
@@ -27,13 +27,8 @@ if [ $1 = "64" ]
 elif [ $1 = "32" ]
     then
         # aarch32
-        # use the right compiler toolchain prefix when building on travis
-        if [ -z "$2" ]
-            then
-                PREFIX=arm-none-eabi-
-            else
-                PREFIX=arm-linux-gnueabihf-
-        fi
+        # use the right compiler toolchain prefix when building
+        PREFIX=arm-none-eabi-
         CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
         TARGET="armv7a-none-eabi"

--- a/03_INTERRUPT/build.sh
+++ b/03_INTERRUPT/build.sh
@@ -16,13 +16,13 @@ if [ $1 = "64" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=aarch64-elf-
+                PREFIX=aarch64-none-elf-
             else
                 PREFIX=aarch64-linux-gnu-
         fi
         CFLAGS="-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0 -C link-arg=-T./link64.ld"
-        TARGET="aarch64-unknown-linux-gnu"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+        TARGET="aarch64-unknown-none"
         KERNEL="kernel8.img"
 elif [ $1 = "32" ]
     then
@@ -30,16 +30,16 @@ elif [ $1 = "32" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=arm-eabi-
+                PREFIX=arm-none-eabi-
             else
                 PREFIX=arm-linux-gnueabihf-
         fi
-        CFLAGS="-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0"
-        TARGET="armv7-unknown-linux-gnueabihf"
+        CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+        TARGET="armv7a-none-eabi"
         KERNEL="kernel7.img"
 else
-    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64" followed by "deploy" if you like to deploy to the device'
+    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64"'
     exit 1
 fi
 
@@ -47,8 +47,9 @@ export CFLAGS="${CFLAGS}"
 export RUSTFLAGS="${RUSTFLAGS}"
 export CC="${PREFIX}gcc"
 export AR="${PREFIX}ar"
-export TARGET="${TARGET}"
-export KERNEL="${KERNEL}"
 
-cargo xbuild --target ${TARGET} --release
-cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+cargo xbuild --target ${TARGET} --release && ${PREFIX}objcopy -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+# cargo objcopy tries to re-build the crates without the propper cross compile target since whatever version
+# so don't use it but rather use the arm toolchain objcopy to achieve the same
+#cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+

--- a/03_INTERRUPT/makefile
+++ b/03_INTERRUPT/makefile
@@ -1,22 +1,22 @@
 #*********************************************************************************
 # Makefile to build the kernel binary ready to be pushed to the Raspberry Pi
 #*********************************************************************************
-all32: export CFLAGS = -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all32: export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0
-all32: export CC = arm-eabi-gcc.exe
-all32: export AR = arm-eabi-ar.exe
+all32: export CFLAGS = -mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all32: export RUSTFLAGS = -C linker=arm-none-eabi-gcc.exe -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld
+all32: export CC = arm-none-eabi-gcc.exe
+all32: export AR = arm-none-eabi-ar.exe
 all32: kernel7
-	cargo objcopy -- -O binary .\\target\\armv7-unknown-linux-gnueabihf\\release\\kernel .\\target\\kernel7.img
+	arm-none-eabi-objcopy -O binary .\\target\\armv7a-none-eabi\\release\\kernel .\\target\\kernel7.img
 
 kernel7:
-	cargo xbuild --target armv7-unknown-linux-gnueabihf --release --bin kernel --target-dir ./target/
+	cargo xbuild --target armv7a-none-eabi --release --bin kernel --target-dir ./target/
 
 all64: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all64: export RUSTFLAGS = -C linker=aarch64-elf-gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld -C opt-level=3 -C debuginfo=0
-all64: export CC = aarch64-elf-gcc
-all64: export AR = aarch64-elf-ar
+all64: export RUSTFLAGS = -C linker=aarch64-none-elf-gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld
+all64: export CC = aarch64-none-elf-gcc
+all64: export AR = aarch64-none-elf-ar
 all64: kernel8
-	cargo objcopy -- -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
+	aarch64-none-elf-objcopy -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
 
 kernel8:
 	cargo xbuild --target aarch64-unknown-linux-gnu --release --bin kernel --target-dir ./target/

--- a/03_INTERRUPT/src/kernel.rs
+++ b/03_INTERRUPT/src/kernel.rs
@@ -82,23 +82,23 @@ define_mmio_register!(
     TIMERCTRL<ReadWrite<u32>@(0x3F00_B408)> {
         // with of the timer counting value
         WIDTH OFFSET(1) [
-            _16Bit: 0,
-            _32Bit: 1
+            _16Bit = 0,
+            _32Bit = 1
         ],
         // flag to enable interrupts raised by the timer
         IRQ OFFSET(5) [
-            ENABLED: 1,
-            DISABLED: 0
+            ENABLED = 1,
+            DISABLED = 0
         ],
         // flag to enable the timer
         TIMER OFFSET(7) [
-            ENABLED: 1,
-            DISABLED: 0
+            ENABLED = 1,
+            DISABLED = 0
         ],
         // flag to enable free-running counter of the timer
         FREERUN OFFSET(9) [
-            ENABLED: 1,
-            DISABLED: 0
+            ENABLED = 1,
+            DISABLED = 0
         ]
     },
     // timer interrupt acknowledge register

--- a/04_I2C/Cargo.toml
+++ b/04_I2C/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "04_i2c"
+name = "TUT_04_i2c"
 authors = ["André Borrmann <pspwizard@gmx.de>"]
 version = "0.0.1" # remember to update html_root_url
 description = """
@@ -21,7 +21,7 @@ cc = "1.0"
 
 [dependencies]
 ruspiro-boot = { version = "0.3", features = [ "ruspiro_pi3", "singlecore" ] }
-ruspiro-allocator = "0.3"
+ruspiro-allocator = "0.4"
 ruspiro-i2c = "0.3"
 
 [features]

--- a/04_I2C/build.sh
+++ b/04_I2C/build.sh
@@ -27,13 +27,8 @@ if [ $1 = "64" ]
 elif [ $1 = "32" ]
     then
         # aarch32
-        # use the right compiler toolchain prefix when building on travis
-        if [ -z "$2" ]
-            then
-                PREFIX=arm-none-eabi-
-            else
-                PREFIX=arm-linux-gnueabihf-
-        fi
+        # use the right compiler toolchain prefix when building
+        PREFIX=arm-none-eabi-
         CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
         RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
         TARGET="armv7a-none-eabi"

--- a/04_I2C/build.sh
+++ b/04_I2C/build.sh
@@ -16,13 +16,13 @@ if [ $1 = "64" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=aarch64-elf-
+                PREFIX=aarch64-none-elf-
             else
                 PREFIX=aarch64-linux-gnu-
         fi
         CFLAGS="-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0 -C link-arg=-T./link64.ld"
-        TARGET="aarch64-unknown-linux-gnu"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+        TARGET="aarch64-unknown-none"
         KERNEL="kernel8.img"
 elif [ $1 = "32" ]
     then
@@ -30,16 +30,16 @@ elif [ $1 = "32" ]
         # use the right compiler toolchain prefix when building on travis
         if [ -z "$2" ]
             then
-                PREFIX=arm-eabi-
+                PREFIX=arm-none-eabi-
             else
                 PREFIX=arm-linux-gnueabihf-
         fi
-        CFLAGS="-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0"
-        TARGET="armv7-unknown-linux-gnueabihf"
+        CFLAGS="-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
+        RUSTFLAGS="-C linker=${PREFIX}gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+        TARGET="armv7a-none-eabi"
         KERNEL="kernel7.img"
 else
-    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64" followed by "deploy" if you like to deploy to the device'
+    echo 'provide the archtitecture to be build. Use either "build.sh 32" or "build.sh 64"'
     exit 1
 fi
 
@@ -47,8 +47,9 @@ export CFLAGS="${CFLAGS}"
 export RUSTFLAGS="${RUSTFLAGS}"
 export CC="${PREFIX}gcc"
 export AR="${PREFIX}ar"
-export TARGET="${TARGET}"
-export KERNEL="${KERNEL}"
 
-cargo xbuild --target ${TARGET} --release
-cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+cargo xbuild --target ${TARGET} --release && ${PREFIX}objcopy -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+# cargo objcopy tries to re-build the crates without the propper cross compile target since whatever version
+# so don't use it but rather use the arm toolchain objcopy to achieve the same
+#cargo objcopy -- -O binary ./target/${TARGET}/release/kernel ./target/${KERNEL}
+

--- a/04_I2C/makefile
+++ b/04_I2C/makefile
@@ -1,22 +1,22 @@
 #*********************************************************************************
 # Makefile to build the kernel binary ready to be pushed to the Raspberry Pi
 #*********************************************************************************
-all32: export CFLAGS = -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all32: export RUSTFLAGS = -C linker=arm-eabi-gcc.exe -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C link-arg=-T./link32.ld -C opt-level=3 -C debuginfo=0
-all32: export CC = arm-eabi-gcc.exe
-all32: export AR = arm-eabi-ar.exe
+all32: export CFLAGS = -mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
+all32: export RUSTFLAGS = -C linker=arm-none-eabi-gcc.exe -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld
+all32: export CC = arm-none-eabi-gcc.exe
+all32: export AR = arm-none-eabi-ar.exe
 all32: kernel7
-	cargo objcopy -- -O binary .\\target\\armv7-unknown-linux-gnueabihf\\release\\kernel .\\target\\kernel7.img
+	arm-none-eabi-objcopy -O binary .\\target\\armv7a-none-eabi\\release\\kernel .\\target\\kernel7.img
 
 kernel7:
-	cargo xbuild --target armv7-unknown-linux-gnueabihf --release --bin kernel --target-dir ./target/
+	cargo xbuild --target armv7a-none-eabi --release --bin kernel --target-dir ./target/
 
 all64: export CFLAGS = -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53
-all64: export RUSTFLAGS = -C linker=aarch64-elf-gcc -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld -C opt-level=3 -C debuginfo=0
-all64: export CC = aarch64-elf-gcc
-all64: export AR = aarch64-elf-ar
+all64: export RUSTFLAGS = -C linker=aarch64-none-elf-gcc -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld
+all64: export CC = aarch64-none-elf-gcc
+all64: export AR = aarch64-none-elf-ar
 all64: kernel8
-	cargo objcopy -- -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
+	aarch64-none-elf-objcopy -O binary .\\target\\aarch64-unknown-linux-gnu\\release\\kernel .\\target\\kernel8.img
 
 kernel8:
 	cargo xbuild --target aarch64-unknown-linux-gnu --release --bin kernel --target-dir ./target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## :banana: v0.5.0
+  - ### :wrench: Maintenance
+    It has been seen that the current Rust versions don't like crate names to start with numbers. So the tutorial cratenames where updated. In dditon - where applicable - the versions to the dependend ``ruspiro`` crates where updated and necessary code adopted to those versions inside the tutorials.
+  - ### :book: Dokumentation
+    Minor updates on the main README.md to reflect a better suited toolchain to be use. The ``aarch64-none-elf`` and ``arm-none-eabi`` with their corresponding Rust targets ``aarch64-unknown-none`` and ``armv7-none-eabi``
+
 ## :pizza: v0.4.0
   - ### :bulb: Features
     Added the following tutorials:<br>

--- a/README.md
+++ b/README.md
@@ -18,25 +18,19 @@ of Rust. We will mainly focus the ``Embedded`` world and thus relying on the ``c
 ### Rust
 To get things started you first need to install Rust on your development machine. The easiest way to 
 do so is by installing the ``rustup`` installer from [https://rustup.rs/](https://rustup.rs/).
-> ::bulb: **HINT** run the ``rustup-init.exe`` on a windows machine
+> ::bulb: **HINT** run the ``rustup-init.exe`` on a windows machine and choose to install ``x86_64-pc-windows-msvc`` as toolchain, the ``nightly`` rust version and the ``minimal`` rust package. This will not install the documentation locally but it has been seen this sometimes causes issues while installing on windows.
 
 ``Rustup`` is mainly a command line interface (CLI) to help you installing and configuring your
 **Rust** environment on your machine. The first thing to do is to install the required tools to 
 build the bare metal kernel we are about to develop. This is done using your prefered CLI like 
 *git bash*, *powershell* on ``Windows``.
 
-```
-$> rustup install nightly-gnu
-```
-This will install the nightly toolchain for your hosting machine. For my windows machine this would
-be ``nightly-x86_64-pc-windows-gnu``. The exact toolchain name could differ based on your host
-machine.
-
 The tool used to build/compile our Rust code is called *cargo*. This is installed as part of the 
 Rust environment. However, as we would like to crosscompile (from a windows host machine in my case)
-we need to install an additional tool called ``xbuild``.
-```
+we need to install two additional tools ``xbuild`` and ``binutils``.
+```shell
 $> cargo install cargo-xbuild
+$> cargo install cargo-binutils
 ```
 
 After installing the cross-build tool we need to also install the crosscompile target to enable Rust
@@ -45,7 +39,7 @@ to build for this target. This is done by adding the following target which fits
 
 Aarch32 build target | Aarch64 build target
 ---------------------|----------------------
-``$> rustup target add armv7-unknown-linux-gnueabihf`` | ``$> rustup target add aarch64-unknown-linux-gnu``
+``$> rustup target add armv7a-none-eabi`` | ``$> rustup target add aarch64-unknown-none``
 
 We finish the Rust installation by adding the source code component as it needs to be available for
 the cross compilation:
@@ -62,8 +56,8 @@ https://developer.arm.com/tools-and-software/open-source-software/developer-tool
 
 Architecture | Windows Toolchain | Linux Toolchain
 -------------|-------------------|-------------------
-Aarch32 | download ``i686-mingw32 hosetd: AArch32 bare-metal target (arm-eabi))`` | ``$>sudo apt-get install gcc-arm-linux-gnueabihf`` 
-Aarch64 | download ``i686-mingw32 hosetd: AArch64 bare-metal target (aarch64-elf)`` | ``$>sudo apt-get install gcc-aarch64-linux-gnu``
+Aarch32 | download ``i686-mingw64 hosetd: AArch32 bare-metal target (arm-eabi))`` | ``$>sudo apt-get install gcc-arm-linux-gnueabihf`` 
+Aarch64 | download ``i686-mingw64 hosetd: AArch64 bare-metal target (aarch64-elf)`` | ``$>sudo apt-get install gcc-aarch64-linux-gnu``
 
 After installing the toolchain it is recommended to adjust the ``PATH`` environment variable to
 point to the ``bin`` and the ``lib`` subfolders of the toolchain installed.
@@ -77,6 +71,24 @@ extension. This will, when used the first time, automatically install the rust l
 for you. If you'd like to install it on your own use this command:
 ```
 $> rustup component add rls --toolchain nightly
+```
+
+In case you'd like to use the RLS to not compile for the host system but also for the desired target some additional steps should
+be considered.
+
+First we should set the global environment variables to tell rust which ``gcc`` and ``ar`` to use for the cross compilation like so
+```shell
+$> set CC_aarch64-unknown-linux-gnu=aarch64-none-elf-gcc.exe
+$> set AR_aarch64-unknown-linux-gnu=aarch64-none-elf-ar.exe
+```
+However, those are best set in the global system environment variables to allow the RLS to pick them up. In macOS/Linux this might be settings for the ``.bashprofile``.
+
+Further more it makes sense within Visual Studio Code to set the following settings (could be done workspace specific):
+```
+    "rust.build_on_save": true,
+    "rust.clippy_preference": "on",
+    "rust.target": "aarch64-unknown-none",
+    "rust.rustflags": "-C linker=aarch64-none-elf-gcc -C target-cpu=cortex-a53"
 ```
 
 ### :computer: Deployment

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ https://developer.arm.com/tools-and-software/open-source-software/developer-tool
 
 Architecture | Windows Toolchain | Linux Toolchain
 -------------|-------------------|-------------------
-Aarch32 | download ``i686-mingw64 hosetd: AArch32 bare-metal target (arm-eabi))`` | ``$>sudo apt-get install gcc-arm-linux-gnueabihf`` 
-Aarch64 | download ``i686-mingw64 hosetd: AArch64 bare-metal target (aarch64-elf)`` | ``$>sudo apt-get install gcc-aarch64-linux-gnu``
+Aarch32 | download ``i686-mingw64 hosetd: AArch32 bare-metal target (arm-none-eabi))`` | ``$>sudo apt-get install gcc-arm-none-abi`` 
+Aarch64 | download ``i686-mingw64 hosetd: AArch64 bare-metal target (aarch64-none-elf)`` | download ``x86_64-linux hosetd: AArch64 bare-metal target (aarch64-none-elf)``
 
 After installing the toolchain it is recommended to adjust the ``PATH`` environment variable to
 point to the ``bin`` and the ``lib`` subfolders of the toolchain installed.


### PR DESCRIPTION
With the latest Rust releases crate names starting with numbers are no longer allowed.
Furthermore the documentation was updated to reflect the better fitting build targets to be used (aarch64-unknown-none / armv7-none-eabi)

All tutorial copiled and tested locally with nightly-x86_64-pc-windows-msvc
The PR will check build in linux pipeline on Travis