### PR TITLE
Update Dependencies

### DIFF
--- a/01_BLINKLED/Makefile.toml
+++ b/01_BLINKLED/Makefile.toml
@@ -6,7 +6,7 @@ CC = "aarch64-none-elf-gcc"
 AR = "aarch64-none-elf-ar"
 OC = "aarch64-none-elf-objcopy"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
 BUILD_TARGET = "aarch64-unknown-linux-gnu"
 KERNEL = "kernel8.img"
 
@@ -14,8 +14,8 @@ KERNEL = "kernel8.img"
 CC = "arm-none-eabi-gcc"
 AR = "arm-none-eabi-ar"
 OC = "arm-none-eabi-objcopy"
-CFLAGS = "-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+CFLAGS = "-march=armv7-a -Wall -O3 -nostdlib -nostartfiles -mfpu=neon -mfloat-abi=hard  -mtune=cortex-a7"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a7 -C target-feature=+strict-align,+a7 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
 BUILD_TARGET = "armv7a-none-eabi"
 KERNEL = "kernel7.img"
 
@@ -32,6 +32,9 @@ KERNEL = "kernel8.img"
 [tasks.kernel]
 command = "${OC}"
 args = ["-O", "binary", "target/${BUILD_TARGET}/release/kernel", "target/${KERNEL}"]
+dependencies = [
+    "xbuild"
+]
 
 [tasks.xbuild]
 command = "cargo"
@@ -39,9 +42,20 @@ args = ["xbuild", "--target", "${BUILD_TARGET}", "--release", "--bin", "kernel",
 
 [tasks.pi3]
 env = { FEATURES = "ruspiro_pi3" }
-run_task = [
-    { name = "xbuild" },
-    { name = "kernel" }
+run_task = "kernel"
+
+[tasks.qemu]
+command = "qemu-system-aarch64"
+args = ["-M", "raspi3", "-kernel", "./target/${KERNEL}", "-serial", "null", "-serial", "stdio",  "-d", "int,mmu", "-D", "qemu.log"]
+dependencies = [
+    "pi3"
+]
+
+[tasks.deploy]
+command = "cargo"
+args = ["ruspiro-push", "-k", "./target/${KERNEL}", "-p", "COM3"]
+dependencies = [
+    "pi3"
 ]
 
 [tasks.clean]

--- a/02_CONSOLE/Makefile.toml
+++ b/02_CONSOLE/Makefile.toml
@@ -6,7 +6,7 @@ CC = "aarch64-none-elf-gcc"
 AR = "aarch64-none-elf-ar"
 OC = "aarch64-none-elf-objcopy"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
 BUILD_TARGET = "aarch64-unknown-linux-gnu"
 KERNEL = "kernel8.img"
 
@@ -14,8 +14,8 @@ KERNEL = "kernel8.img"
 CC = "arm-none-eabi-gcc"
 AR = "arm-none-eabi-ar"
 OC = "arm-none-eabi-objcopy"
-CFLAGS = "-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+CFLAGS = "-march=armv7-a -Wall -O3 -nostdlib -nostartfiles -mfpu=neon -mfloat-abi=hard  -mtune=cortex-a7"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a7 -C target-feature=+strict-align,+a7 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
 BUILD_TARGET = "armv7a-none-eabi"
 KERNEL = "kernel7.img"
 
@@ -32,6 +32,9 @@ KERNEL = "kernel8.img"
 [tasks.kernel]
 command = "${OC}"
 args = ["-O", "binary", "target/${BUILD_TARGET}/release/kernel", "target/${KERNEL}"]
+dependencies = [
+    "xbuild"
+]
 
 [tasks.xbuild]
 command = "cargo"
@@ -39,9 +42,20 @@ args = ["xbuild", "--target", "${BUILD_TARGET}", "--release", "--bin", "kernel",
 
 [tasks.pi3]
 env = { FEATURES = "ruspiro_pi3" }
-run_task = [
-    { name = "xbuild" },
-    { name = "kernel" }
+run_task = "kernel"
+
+[tasks.qemu]
+command = "qemu-system-aarch64"
+args = ["-M", "raspi3", "-kernel", "./target/${KERNEL}", "-serial", "null", "-serial", "stdio",  "-d", "int,mmu", "-D", "qemu.log"]
+dependencies = [
+    "pi3"
+]
+
+[tasks.deploy]
+command = "cargo"
+args = ["ruspiro-push", "-k", "./target/${KERNEL}", "-p", "COM3"]
+dependencies = [
+    "pi3"
 ]
 
 [tasks.clean]

--- a/03_INTERRUPT/Makefile.toml
+++ b/03_INTERRUPT/Makefile.toml
@@ -6,7 +6,7 @@ CC = "aarch64-none-elf-gcc"
 AR = "aarch64-none-elf-ar"
 OC = "aarch64-none-elf-objcopy"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
 BUILD_TARGET = "aarch64-unknown-linux-gnu"
 KERNEL = "kernel8.img"
 
@@ -14,8 +14,8 @@ KERNEL = "kernel8.img"
 CC = "arm-none-eabi-gcc"
 AR = "arm-none-eabi-ar"
 OC = "arm-none-eabi-objcopy"
-CFLAGS = "-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+CFLAGS = "-march=armv7-a -Wall -O3 -nostdlib -nostartfiles -mfpu=neon -mfloat-abi=hard  -mtune=cortex-a7"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a7 -C target-feature=+strict-align,+a7 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
 BUILD_TARGET = "armv7a-none-eabi"
 KERNEL = "kernel7.img"
 
@@ -32,6 +32,9 @@ KERNEL = "kernel8.img"
 [tasks.kernel]
 command = "${OC}"
 args = ["-O", "binary", "target/${BUILD_TARGET}/release/kernel", "target/${KERNEL}"]
+dependencies = [
+    "xbuild"
+]
 
 [tasks.xbuild]
 command = "cargo"
@@ -39,9 +42,20 @@ args = ["xbuild", "--target", "${BUILD_TARGET}", "--release", "--bin", "kernel",
 
 [tasks.pi3]
 env = { FEATURES = "ruspiro_pi3" }
-run_task = [
-    { name = "xbuild" },
-    { name = "kernel" }
+run_task = "kernel"
+
+[tasks.qemu]
+command = "qemu-system-aarch64"
+args = ["-M", "raspi3", "-kernel", "./target/${KERNEL}", "-serial", "null", "-serial", "stdio",  "-d", "int,mmu", "-D", "qemu.log"]
+dependencies = [
+    "pi3"
+]
+
+[tasks.deploy]
+command = "cargo"
+args = ["ruspiro-push", "-k", "./target/${KERNEL}", "-p", "COM3"]
+dependencies = [
+    "pi3"
 ]
 
 [tasks.clean]

--- a/04_I2C/Makefile.toml
+++ b/04_I2C/Makefile.toml
@@ -6,7 +6,7 @@ CC = "aarch64-none-elf-gcc"
 AR = "aarch64-none-elf-ar"
 OC = "aarch64-none-elf-objcopy"
 CFLAGS = "-march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C target-feature=+strict-align,+a53,+fp-armv8,+neon -C link-arg=-nostartfiles -C link-arg=-T./link64.ld"
 BUILD_TARGET = "aarch64-unknown-linux-gnu"
 KERNEL = "kernel8.img"
 
@@ -14,8 +14,8 @@ KERNEL = "kernel8.img"
 CC = "arm-none-eabi-gcc"
 AR = "arm-none-eabi-ar"
 OC = "arm-none-eabi-objcopy"
-CFLAGS = "-mcpu=cortex-a53 -march=armv7-a -mfpu=neon -mfloat-abi=softfp -Wall -O3 -nostdlib -nostartfiles"
-RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a53 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
+CFLAGS = "-march=armv7-a -Wall -O3 -nostdlib -nostartfiles -mfpu=neon -mfloat-abi=hard  -mtune=cortex-a7"
+RUSTFLAGS = "-C linker=${CC} -C target-cpu=cortex-a7 -C target-feature=+strict-align,+a7 -C link-arg=-nostartfiles -C link-arg=-T./link32.ld"
 BUILD_TARGET = "armv7a-none-eabi"
 KERNEL = "kernel7.img"
 
@@ -32,6 +32,9 @@ KERNEL = "kernel8.img"
 [tasks.kernel]
 command = "${OC}"
 args = ["-O", "binary", "target/${BUILD_TARGET}/release/kernel", "target/${KERNEL}"]
+dependencies = [
+    "xbuild"
+]
 
 [tasks.xbuild]
 command = "cargo"
@@ -39,9 +42,20 @@ args = ["xbuild", "--target", "${BUILD_TARGET}", "--release", "--bin", "kernel",
 
 [tasks.pi3]
 env = { FEATURES = "ruspiro_pi3" }
-run_task = [
-    { name = "xbuild" },
-    { name = "kernel" }
+run_task = "kernel"
+
+[tasks.qemu]
+command = "qemu-system-aarch64"
+args = ["-M", "raspi3", "-kernel", "./target/${KERNEL}", "-serial", "null", "-serial", "stdio",  "-d", "int,mmu", "-D", "qemu.log"]
+dependencies = [
+    "pi3"
+]
+
+[tasks.deploy]
+command = "cargo"
+args = ["ruspiro-push", "-k", "./target/${KERNEL}", "-p", "COM3"]
+dependencies = [
+    "pi3"
 ]
 
 [tasks.clean]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## :banana: v0.5.2
+  - ### :wrench: Maintenance
+    Update the tutorials to use the latest versions of the dependent RusPiRo crates to run woth the current version of the Rust nightly compiler.
+
 ## :banana: v0.5.1
   - ### :wrench: Maintenance
     Use ``cargo-make`` cargo plugin to conviniently build the tutorials cross system. This reduces the maintenance efforts

--- a/README.md
+++ b/README.md
@@ -46,16 +46,14 @@ Aarch32 build target | Aarch64 build target
 
 We finish the Rust installation by adding the source code component as it needs to be available for
 the cross compilation:
-```
+
+```shell
 $> rustup component add rust-src
 ```
 
 ### :gear: Cross compiler
 
-After finishing all the rust configurations we would need a cross compilation toolchain available 
-for our host machine and able to compile to the desired target system architecture. For the windows 
-host machine this could be donwloaded here:
-https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads .
+After finishing all the rust configurations we would need a cross compilation toolchain available for our host machine and able to compile to the desired target system architecture. For the windows host machine this could be donwloaded here: https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads .
 
 Architecture | Windows Toolchain | Linux Toolchain
 -------------|-------------------|-------------------
@@ -67,27 +65,28 @@ point to the ``bin`` and the ``lib`` subfolders of the toolchain installed.
 
 ### :pager: IDE
 
-To write the Rust code you would need an IDE that supports you in writing this code and also giving
-code completion and early hints on the syntax. For this purpose I use and recommend [Visual Studio Code](https://code.visualstudio.com/).
-Once downloaded and installed you should at least install the [Rust Language Server](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
-extension. This will, when used the first time, automatically install the rust language server (RLS)
-for you. If you'd like to install it on your own use this command:
-```
+To write the Rust code you would need an IDE that supports you in writing this code and also giving code completion and early hints on the syntax. For this purpose I use and recommend [Visual Studio Code](https://code.visualstudio.com/). Once downloaded and installed you should at least install the [Rust Language Server](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) extension. This will, when used the first time, automatically install the rust language server (RLS) for you. If you'd like to install it on your own use this command:
+
+```shell
 $> rustup component add rls --toolchain nightly
 ```
 
-In case you'd like to use the RLS to not compile for the host system but also for the desired target some additional steps should
-be considered.
+Another great extension to be used with Visual Studio Code is the [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer) that can be used as alternative to the `Rust Language Server` and does provide some additional useful features. 
+#### 
+In case you'd like to use the RLS to not compile for the host system but also for the desired target some additional steps should be considered.
 
 First we should set the global environment variables to tell rust which ``gcc`` and ``ar`` to use for the cross compilation like so
+
 ```shell
-$> set CC_aarch64-unknown-linux-gnu=aarch64-none-elf-gcc.exe
-$> set AR_aarch64-unknown-linux-gnu=aarch64-none-elf-ar.exe
+$> set CC_aarch64-unknown-none=aarch64-none-elf-gcc.exe
+$> set AR_aarch64-unknown-none=aarch64-none-elf-ar.exe
 ```
+
 However, those are best set in the global system environment variables to allow the RLS to pick them up. In macOS/Linux this might be settings for the ``.bashprofile``.
 
 Further more it makes sense within Visual Studio Code to set the following settings (could be done workspace specific):
-```
+
+```json
     "rust.build_on_save": true,
     "rust.clippy_preference": "on",
     "rust.target": "aarch64-unknown-none",
@@ -115,12 +114,14 @@ GROUND on Raspberry Pi). If this is done you could use a cargo subcommand to pus
 kernel file to the Raspberry Pi.
 
 Install the subcommand with:
-```
+
+```shell
 $> cargo install cargo-ruspiro-push
 ```
 
 And then execute it from your projects root folder like so:
-```
+
+```shell
 $> cargo ruspiro-push -k ./target/kernel8.img -p COM5
 ```
 Adjust the name of your kernel file and the serial port name of this command to your needs.

--- a/README.md
+++ b/README.md
@@ -71,47 +71,13 @@ To write the Rust code you would need an IDE that supports you in writing this c
 $> rustup component add rls --toolchain nightly
 ```
 
-Another great extension to be used with Visual Studio Code is the [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer) that can be used as alternative to the `Rust Language Server` and does provide some additional useful features. 
-#### 
-In case you'd like to use the RLS to not compile for the host system but also for the desired target some additional steps should be considered.
-
-First we should set the global environment variables to tell rust which ``gcc`` and ``ar`` to use for the cross compilation like so
-
-```shell
-$> set CC_aarch64-unknown-none=aarch64-none-elf-gcc.exe
-$> set AR_aarch64-unknown-none=aarch64-none-elf-ar.exe
-```
-
-However, those are best set in the global system environment variables to allow the RLS to pick them up. In macOS/Linux this might be settings for the ``.bashprofile``.
-
-Further more it makes sense within Visual Studio Code to set the following settings (could be done workspace specific):
-
-```json
-    "rust.build_on_save": true,
-    "rust.clippy_preference": "on",
-    "rust.target": "aarch64-unknown-none",
-    "rust.rustflags": "-C linker=aarch64-none-elf-gcc -C target-cpu=cortex-a53"
-```
+Another great extension to be used with Visual Studio Code is the [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer) that can be used as alternative to the `Rust Language Server` and does provide some additional useful features.
 
 ### :computer: Deployment
 
-The result of a successfull build will be a binary kernel file. The easiest way to get this executed
-on the Raspberry Pi is to copy it onto a fresh FAT32 formatted SD card. This SD card need to contain
-additional files like ``bootcode.bin``, ``start.elf`` and ``fixup.dat``. They can be found [here](../RPi)
-or the lates official versions in this [Github Repo](https://github.com/raspberrypi/firmware/tree/master/boot).
-The files with ``_x`` suffix indicate extended versions of the Raspberry Pi Firmware that enable
-access to additional hardware like the built-in bluetooth controller and the like. So if you foresee
-to use all the peripherals of the Raspberry Pi in future projects I recommnd to use those files.
+The result of a successfull build will be a binary kernel file. The easiest way to get this executed on the Raspberry Pi is to copy it onto a fresh FAT32 formatted SD card. This SD card need to contain additional files like ``bootcode.bin``, ``start.elf`` and ``fixup.dat``. They can be found [here](../RPi) or the lates official versions in this [Github Repo](https://github.com/raspberrypi/firmware/tree/master/boot). The files with ``_x`` suffix indicate extended versions of the Raspberry Pi Firmware that enable access to additional hardware like the built-in bluetooth controller and the like. So if you foresee to use all the peripherals of the Raspberry Pi in future projects I recommnd to use those files.
 
-
-Building the kernel binary file and repeatedly put it onto the SD card of the Raspberry Pi will 
-pretty soon get cumbersome. To reduce this "SD card dance" you will find an bootloader image file in
-the [RPi](../RPi) subfolder to be put on the SD card instead of your build kernel file. Once you 
-power on the Raspberry Pi this bootloader waits on the miniUART to receive a new kernel binary to 
-get executed. For this to work the Raspberry Pi need to be connected to a serial port of the
-development machine. This is usually achieved with a simple TTL-USB dongle (use GPIO 14, 15 and
-GROUND on Raspberry Pi). If this is done you could use a cargo subcommand to push your new built
-kernel file to the Raspberry Pi.
+Building the kernel binary file and repeatedly put it onto the SD card of the Raspberry Pi will  pretty soon get cumbersome. To reduce this "SD card dance" you will find an bootloader image file in the [RPi](../RPi) subfolder to be put on the SD card instead of your build kernel file. Once you  power on the Raspberry Pi this bootloader waits on the miniUART to receive a new kernel binary to get executed. For this to work the Raspberry Pi need to be connected to a serial port of the development machine. This is usually achieved with a simple TTL-USB dongle (use GPIO 14, 15 and GROUND on Raspberry Pi). If this is done you could use a cargo subcommand to push your new built kernel file to the Raspberry Pi.
 
 Install the subcommand with:
 
@@ -124,10 +90,14 @@ And then execute it from your projects root folder like so:
 ```shell
 $> cargo ruspiro-push -k ./target/kernel8.img -p COM5
 ```
+
 Adjust the name of your kernel file and the serial port name of this command to your needs.
 > :bulb: **HINT** The ``ruspiro-push`` tool determines based on the kernel file name whether to run
 > in Aarch32 (kernel7.img) or Aarch64 (kernel8.img) mode. If you use any other file name provide the
 > ``-a`` parameter to selct the target architecture.
+
+
+> :bulb: **HINT** The `Makefile.toml` of the examples of this tutorial series also provides a build step to build and deploy the kernel to the Raspberry Pi connected to the hostinng machine. Simply execute it with `cargo make --profile a64 deploy`. The console of the host machine will mirror the console/UART1 output of the Raspberry Pi.
 
 ## :tada: Ready to go...
 


### PR DESCRIPTION
After fixing the build issues in the dependent *RusPiRo*  crates to successfully compile with the current nightly Rust compiler version the tutorials needed to reflect this.

The depentent crates were mainly updated to use the `llvm_asm!` macro for inline assembly instead of `asm!`.